### PR TITLE
Cleanup of IntelliSense and Go To Definition Behavior

### DIFF
--- a/src/Scripts/_intellisense-tests.js
+++ b/src/Scripts/_intellisense-tests.js
@@ -1,4 +1,4 @@
-﻿AngularJS_VisualStudio_Intellisense.setLogLevelVerbose();
+﻿_$AngularJS_VisualStudio_Intellisense.setLogLevelVerbose();
 
 (function (angular) {
     // Create a test module.

--- a/src/Scripts/_intellisense.js
+++ b/src/Scripts/_intellisense.js
@@ -17,8 +17,8 @@
     // Set the current log level to one of the log levels above in order to view log messages.
     var CURRENT_LOG_LEVEL = LOG_LEVEL.OFF;
 
-    // Expose a way to set the log level from any file.
-    window.AngularJS_VisualStudio_Intellisense = {
+    // Expose a hidden object that may be used to set the log level from any file.
+    window._$AngularJS_VisualStudio_Intellisense = {
         setLogLevelVerbose: function () { CURRENT_LOG_LEVEL = LOG_LEVEL.VERBOSE; },
         setLogLevelInfo: function () { CURRENT_LOG_LEVEL = LOG_LEVEL.INFO; },
         setLogLevelWarn: function () { CURRENT_LOG_LEVEL = LOG_LEVEL.WARN; },
@@ -321,6 +321,8 @@
         return obj;
     };
 
+    intellisense.redirectDefinition(angular.forEach, originalForEach);
+
     // Search the window object for globally-defined angular modules, and track them if they are found.
     if (window) {
         forEach(window, function (obj) {
@@ -371,6 +373,7 @@
 
         return returnValue;
     };
+    intellisense.redirectDefinition(angular.module, originalModuleFunction);
 
     function trackModule(moduleOrName) {
         var moduleName, module;


### PR DESCRIPTION
In this pull request I'm submitting a couple changes to cleanup IntelliSense and make features like Go To Definition work correctly.
-=-=-=-=-=-=-=-=-=-=-=
Changed the AngularJS_VisualStudio_Intellisense so that it is always hidden from IntelliSense (using the _$ prefix).

Resetting the "definitions" for angular.module and angular.forEach back to their original functions, usning intellisense.redirectDefinition - this doesn't alter the behavior of the extension, but enables features like Go To Definition to work correctly.
